### PR TITLE
✨ Add lyrics overlay mode

### DIFF
--- a/lib/core/navigation_provider.dart
+++ b/lib/core/navigation_provider.dart
@@ -99,7 +99,8 @@ class NavigationNotifier extends StateNotifier<NavigationState> {
     required List<Song> songs,
   }) {
     // Push current state to history
-    final newHistory = List<NavigationState>.from(state.history)..add(_captureCurrentState());
+    final newHistory = List<NavigationState>.from(state.history)
+      ..add(_captureCurrentState());
 
     state = state.copyWith(
       activeItem: NavItem.collectionDetail,
@@ -138,5 +139,5 @@ class NavigationNotifier extends StateNotifier<NavigationState> {
 
 final appNavigationProvider =
     StateNotifierProvider<NavigationNotifier, NavigationState>((ref) {
-  return NavigationNotifier();
-});
+      return NavigationNotifier();
+    });

--- a/lib/core/providers.dart
+++ b/lib/core/providers.dart
@@ -21,3 +21,5 @@ final searchFocusNodeProvider = Provider<FocusNode>((ref) {
   ref.onDispose(() => node.dispose());
   return node;
 });
+
+final overlayModeProvider = StateProvider<bool>((ref) => false);

--- a/lib/core/theme_provider.dart
+++ b/lib/core/theme_provider.dart
@@ -126,7 +126,9 @@ class ThemeNotifier extends StateNotifier<ThemeState> {
   }
 
   void _resetTheme() {
-    debugPrint('🔄 Resetting theme to accent color: ${Color(_settings.accentColor)}');
+    debugPrint(
+      '🔄 Resetting theme to accent color: ${Color(_settings.accentColor)}',
+    );
     state = state.copyWith(
       colorScheme: ColorScheme.fromSeed(
         seedColor: Color(_settings.accentColor),

--- a/lib/features/library/presentation/library_grids.dart
+++ b/lib/features/library/presentation/library_grids.dart
@@ -65,7 +65,9 @@ class _AlbumCard extends ConsumerWidget {
             .filter()
             .albumEqualTo(album.name)
             .findAll();
-        ref.read(appNavigationProvider.notifier).showCollection(
+        ref
+            .read(appNavigationProvider.notifier)
+            .showCollection(
               title: album.name,
               subtitle: album.artist,
               art: album.artPath,
@@ -91,71 +93,71 @@ class _AlbumCard extends ConsumerWidget {
               : null,
         ),
         child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(16),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withOpacity(0.3),
-                        blurRadius: 15,
-                        offset: const Offset(0, 8),
-                      ),
-                    ],
-                    color: Colors.white.withOpacity(0.05),
-                  ),
-                  child: album.artPath != null
-                      ? ClipRRect(
-                          borderRadius: BorderRadius.circular(16),
-                          child: OptimizedImage(
-                            imagePath: album.artPath,
-                            fit: BoxFit.cover,
-                            placeholder: const Center(
-                              child: Icon(
-                                LucideIcons.disc,
-                                size: 48,
-                                color: Colors.grey,
-                              ),
-                            ),
-                          ),
-                        )
-                      : const Center(
-                          child: Icon(
-                            LucideIcons.disc,
-                            size: 48,
-                            color: Colors.grey,
-                          ),
-                        ),
-                ),
-              ),
-              const SizedBox(height: 12),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      album.name,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.normal,
-                        fontSize: 14,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    Text(
-                      album.artist ?? 'Unknown Artist',
-                      style: TextStyle(color: Colors.grey[400], fontSize: 12),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(16),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.3),
+                      blurRadius: 15,
+                      offset: const Offset(0, 8),
                     ),
                   ],
+                  color: Colors.white.withOpacity(0.05),
                 ),
+                child: album.artPath != null
+                    ? ClipRRect(
+                        borderRadius: BorderRadius.circular(16),
+                        child: OptimizedImage(
+                          imagePath: album.artPath,
+                          fit: BoxFit.cover,
+                          placeholder: const Center(
+                            child: Icon(
+                              LucideIcons.disc,
+                              size: 48,
+                              color: Colors.grey,
+                            ),
+                          ),
+                        ),
+                      )
+                    : const Center(
+                        child: Icon(
+                          LucideIcons.disc,
+                          size: 48,
+                          color: Colors.grey,
+                        ),
+                      ),
               ),
-            ],
-          ),
+            ),
+            const SizedBox(height: 12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    album.name,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.normal,
+                      fontSize: 14,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    album.artist ?? 'Unknown Artist',
+                    style: TextStyle(color: Colors.grey[400], fontSize: 12),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -205,7 +207,9 @@ class _ArtistCard extends ConsumerWidget {
             .filter()
             .artistEqualTo(artist.name)
             .findAll();
-        ref.read(appNavigationProvider.notifier).showCollection(
+        ref
+            .read(appNavigationProvider.notifier)
+            .showCollection(
               title: artist.name,
               art: artist.artPath,
               imageUrl: artist.artistImageUrl,

--- a/lib/features/library/presentation/songs_list.dart
+++ b/lib/features/library/presentation/songs_list.dart
@@ -44,45 +44,43 @@ class SongsList extends ConsumerWidget {
                 style: const TextStyle(color: Colors.grey, fontSize: 13),
               ),
               TextButton.icon(
-                    onPressed: () async {
-                      final confirm = await showDialog<bool>(
-                        context: context,
-                        builder: (context) => AlertDialog(
-                          title: Text(l10n.resetLibrary),
-                          content: const Text(
-                            'This will clear all songs, albums, and artists and perform a full rescan of your folders.',
-                          ),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.pop(context, false),
-                              child: const Text('Cancel'),
-                            ),
-                            TextButton(
-                              onPressed: () => Navigator.pop(context, true),
-                              child: const Text(
-                                'Reset',
-                                style: TextStyle(color: Colors.red),
-                              ),
-                            ),
-                          ],
+                onPressed: () async {
+                  final confirm = await showDialog<bool>(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      title: Text(l10n.resetLibrary),
+                      content: const Text(
+                        'This will clear all songs, albums, and artists and perform a full rescan of your folders.',
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: const Text('Cancel'),
                         ),
-                      );
-                      if (confirm == true) {
-                        await ref
-                            .read(libraryProvider.notifier)
-                            .resetAndRescan();
-                      }
-                    },
-                    icon: const Icon(LucideIcons.refreshCw, size: 16),
-                    label: Text(
-                      l10n.resetLibrary,
-                      style: const TextStyle(fontSize: 13),
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, true),
+                          child: const Text(
+                            'Reset',
+                            style: TextStyle(color: Colors.red),
+                          ),
+                        ),
+                      ],
                     ),
-                    style: TextButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
-                      foregroundColor: Colors.red[300],
-                    ),
-                  ),
+                  );
+                  if (confirm == true) {
+                    await ref.read(libraryProvider.notifier).resetAndRescan();
+                  }
+                },
+                icon: const Icon(LucideIcons.refreshCw, size: 16),
+                label: Text(
+                  l10n.resetLibrary,
+                  style: const TextStyle(fontSize: 13),
+                ),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  foregroundColor: Colors.red[300],
+                ),
+              ),
               // Row(
               //   children: [
               //     TextButton.icon(

--- a/lib/features/playback/presentation/lyrics_view.dart
+++ b/lib/features/playback/presentation/lyrics_view.dart
@@ -4,8 +4,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:looper_player/features/library/domain/models/models.dart';
 import 'package:looper_player/features/playback/presentation/playback_notifier.dart';
 import 'package:looper_player/features/playback/presentation/lyrics_notifier.dart';
+import 'package:lucide_icons/lucide_icons.dart';
 import 'widgets/advanced_lyric_renderer.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'overlay_service.dart';
 
 enum LyricsSyncMode { line, word, char }
 
@@ -22,10 +24,14 @@ class _LyricsViewState extends ConsumerState<LyricsView> {
   @override
   Widget build(BuildContext context) {
     final lyricsState = ref.watch(lyricsProvider);
+    final currentSong = ref.watch(
+      playbackProvider.select((s) => s.currentSong),
+    );
     final primaryColor = Theme.of(context).colorScheme.primary;
 
     return Column(
       children: [
+        _buildHeader(currentSong),
         if (_syncMode != LyricsSyncMode.line) _buildDisclaimer(),
         Expanded(
           child: lyricsState.isLoading
@@ -116,7 +122,23 @@ class _LyricsViewState extends ConsumerState<LyricsView> {
                       _buildSongInfoCompact(currentSong, isShort),
                       SizedBox(height: isShort ? 8 : 16),
                     ],
-                    _buildModeSelector(isShort),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        _buildModeSelector(isShort),
+                        const SizedBox(width: 16),
+                        IconButton(
+                          icon: const Icon(
+                            LucideIcons.pictureInPicture2,
+                            color: Colors.white70,
+                          ),
+                          tooltip: 'Overlay Lyrics',
+                          onPressed: () {
+                            ref.read(overlayServiceProvider).toggleOverlay();
+                          },
+                        ),
+                      ],
+                    ),
                   ],
                 )
               : Row(
@@ -127,6 +149,17 @@ class _LyricsViewState extends ConsumerState<LyricsView> {
                       Expanded(child: _buildSongText(currentSong, isShort)),
                     ],
                     _buildModeSelector(isShort),
+                    const SizedBox(width: 16),
+                    IconButton(
+                      icon: const Icon(
+                        LucideIcons.pictureInPicture2,
+                        color: Colors.white70,
+                      ),
+                      tooltip: 'Overlay Lyrics',
+                      onPressed: () {
+                        ref.read(overlayServiceProvider).toggleOverlay();
+                      },
+                    ),
                   ],
                 ),
         );
@@ -141,16 +174,15 @@ class _LyricsViewState extends ConsumerState<LyricsView> {
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
         color: Colors.white.withOpacity(0.05),
-        image: currentSong.artPath != null
-            ? DecorationImage(
-                image: FileImage(File(currentSong.artPath!)),
-                fit: BoxFit.cover,
-              )
-            : null,
       ),
+      clipBehavior: Clip.antiAlias,
       child: currentSong.artPath == null
           ? Icon(Icons.music_note, color: Colors.grey[600], size: size / 2)
-          : null,
+          : Image.file(
+              File(currentSong.artPath!),
+              fit: BoxFit.cover,
+              cacheWidth: size.toInt() * 2,
+            ),
     );
   }
 
@@ -189,20 +221,19 @@ class _LyricsViewState extends ConsumerState<LyricsView> {
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(8),
             color: Colors.white.withOpacity(0.05),
-            image: currentSong.artPath != null
-                ? DecorationImage(
-                    image: FileImage(File(currentSong.artPath!)),
-                    fit: BoxFit.cover,
-                  )
-                : null,
           ),
+          clipBehavior: Clip.antiAlias,
           child: currentSong.artPath == null
               ? Icon(
                   Icons.music_note,
                   color: Colors.grey[600],
                   size: isShort ? 20 : 24,
                 )
-              : null,
+              : Image.file(
+                  File(currentSong.artPath!),
+                  fit: BoxFit.cover,
+                  cacheWidth: (isShort ? 40 : 50) * 2,
+                ),
         ),
         const SizedBox(width: 12),
         Flexible(

--- a/lib/features/playback/presentation/overlay_service.dart
+++ b/lib/features/playback/presentation/overlay_service.dart
@@ -1,0 +1,61 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:window_manager/window_manager.dart';
+import '../../../core/providers.dart';
+
+final overlayServiceProvider = Provider<OverlayService>((ref) {
+  return OverlayService(ref);
+});
+
+class OverlayService {
+  final Ref ref;
+  Rect? _previousBounds;
+
+  OverlayService(this.ref);
+
+  Future<void> toggleOverlay() async {
+    final isOverlay = ref.read(overlayModeProvider);
+    if (isOverlay) {
+      await exitOverlay();
+    } else {
+      await enterOverlay();
+    }
+  }
+
+  Future<void> enterOverlay() async {
+    _previousBounds = await windowManager.getBounds();
+
+    // Switch state first to trigger UI rebuild
+    ref.read(overlayModeProvider.notifier).state = true;
+
+    await windowManager.setAsFrameless();
+    await windowManager.setHasShadow(false);
+    await windowManager.setAlwaysOnTop(true);
+    await windowManager.setBackgroundColor(Colors.transparent);
+
+    // Set to a smaller size suitable for lyrics
+    await windowManager.setSize(const Size(500, 150));
+    await windowManager.setOpacity(
+      1.0,
+    ); // Make sure the window isn't entirely invisible
+  }
+
+  Future<void> exitOverlay() async {
+    // Switch state back to trigger UI rebuild
+    ref.read(overlayModeProvider.notifier).state = false;
+
+    await windowManager.setAlwaysOnTop(false);
+    await windowManager.setHasShadow(true);
+
+    // Revert styling
+    await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
+
+    if (_previousBounds != null) {
+      await windowManager.setBounds(_previousBounds);
+    } else {
+      await windowManager.setSize(const Size(1300, 700));
+      await windowManager.center();
+    }
+  }
+}

--- a/lib/features/playback/presentation/widgets/advanced_lyric_line.dart
+++ b/lib/features/playback/presentation/widgets/advanced_lyric_line.dart
@@ -38,16 +38,15 @@ class AdvancedLyricLine extends StatelessWidget {
 
     // Language-aware font selection
     final bool isHindiText = _isHindi(line.text);
-    final baseStyle = (isHindiText
-            ? GoogleFonts.poppins()
-            : GoogleFonts.spaceGrotesk())
-        .copyWith(
-      fontSize: isActive ? 36 : 32,
-      fontWeight: isActive ? FontWeight.w800 : FontWeight.w600,
-      letterSpacing: isHindiText ? 0.0 : -0.5,
-      height: 1.2,
-      color: Colors.white.withOpacity(isActive ? 1.0 : lineOpacity),
-    );
+    final baseStyle =
+        (isHindiText ? GoogleFonts.poppins() : GoogleFonts.spaceGrotesk())
+            .copyWith(
+              fontSize: isActive ? 36 : 32,
+              fontWeight: isActive ? FontWeight.w800 : FontWeight.w600,
+              letterSpacing: isHindiText ? 0.0 : -0.5,
+              height: 1.2,
+              color: Colors.white.withOpacity(isActive ? 1.0 : lineOpacity),
+            );
 
     // Active color (Theme Primary)
     final activeColor = Theme.of(context).colorScheme.primary;

--- a/lib/features/playback/presentation/widgets/advanced_lyric_renderer.dart
+++ b/lib/features/playback/presentation/widgets/advanced_lyric_renderer.dart
@@ -122,7 +122,7 @@ class _AdvancedLyricRendererState extends State<AdvancedLyricRenderer> {
             currentPosition: widget.currentPosition,
             mode: widget.mode,
             isActive: isActive,
-            relativeIndex: _currentLineIndex == -1 
+            relativeIndex: _currentLineIndex == -1
                 ? index // If nothing active, treat first line as reference or just use index
                 : (index - _currentLineIndex).abs(),
             onTap: () => widget.onSeek(line.startTime),

--- a/lib/features/playback/presentation/widgets/overlay_lyrics_widget.dart
+++ b/lib/features/playback/presentation/widgets/overlay_lyrics_widget.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:window_manager/window_manager.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+
+import '../lyrics_notifier.dart';
+import '../playback_notifier.dart';
+import '../overlay_service.dart';
+
+class OverlayLyricsWidget extends ConsumerStatefulWidget {
+  const OverlayLyricsWidget({super.key});
+
+  @override
+  ConsumerState<OverlayLyricsWidget> createState() =>
+      _OverlayLyricsWidgetState();
+}
+
+class _OverlayLyricsWidgetState extends ConsumerState<OverlayLyricsWidget> {
+  @override
+  Widget build(BuildContext context) {
+    // Only rebuild when the parsed lines change
+    final lines = ref.watch(
+      lyricsProvider.select((state) => state.parsedLines),
+    );
+
+    return GestureDetector(
+      onPanStart: (details) {
+        windowManager.startDragging();
+      },
+      onDoubleTap: () {
+        ref.read(overlayServiceProvider).toggleOverlay();
+      },
+      child: Container(
+        color: Colors.black.withOpacity(0.5),
+        padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0),
+        child: Stack(
+          children: [
+            Center(
+              child: Consumer(
+                builder: (context, ref, child) {
+                  // Optimization: only rebuild when the current line index changes
+                  final lineIndex = ref.watch(
+                    playbackProvider.select((s) {
+                      if (lines.isEmpty) return -1;
+                      return lines.indexWhere(
+                        (line) =>
+                            s.position >= line.startTime &&
+                            s.position < line.endTime,
+                      );
+                    }),
+                  );
+
+                  String currentLine = "Looper Player";
+                  String nextLine = "";
+
+                  if (lineIndex != -1) {
+                    currentLine = lines[lineIndex].text;
+                    if (lineIndex + 1 < lines.length) {
+                      nextLine = lines[lineIndex + 1].text;
+                    }
+                  }
+
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        currentLine,
+                        textAlign: TextAlign.center,
+                        style: GoogleFonts.spaceGrotesk(
+                          fontSize: 26,
+                          fontWeight: FontWeight.bold,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      if (nextLine.isNotEmpty) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          nextLine,
+                          textAlign: TextAlign.center,
+                          style: GoogleFonts.spaceGrotesk(
+                            fontSize: 16,
+                            color: Colors.white70,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ],
+                  );
+                },
+              ),
+            ),
+            Positioned(
+              top: 0,
+              right: 0,
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(
+                      LucideIcons.x,
+                      color: Colors.white54,
+                      size: 20,
+                    ),
+                    onPressed: () {
+                      ref.read(overlayServiceProvider).toggleOverlay();
+                    },
+                    hoverColor: Colors.white10,
+                    splashRadius: 20,
+                  ),
+                ],
+              ),
+            ),
+            // Resize handle on the bottom right
+            Positioned(
+              bottom: -5,
+              right: -5,
+              child: GestureDetector(
+                onPanStart: (details) {
+                  windowManager.startResizing(ResizeEdge.bottomRight);
+                },
+                child: MouseRegion(
+                  cursor: SystemMouseCursors.resizeDownRight,
+                  child: Container(
+                    width: 20,
+                    height: 20,
+                    color: Colors.transparent,
+                    child: const Icon(
+                      Icons.keyboard_arrow_right,
+                      size: 14,
+                      color: Colors.white24,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,9 +41,7 @@ void main(List<String> args) async {
     skipTaskbar: false,
     titleBarStyle: TitleBarStyle.hidden,
     title: 'Looper Player',
-    // fullScreen: true,
-
-
+    backgroundColor: Colors.transparent,
   );
 
   await windowManager.waitUntilReadyToShow(windowOptions, () async {
@@ -71,6 +69,7 @@ class MyApp extends ConsumerWidget {
       return MaterialApp(
         debugShowCheckedModeBanner: false,
         title: 'Looper Player',
+        color: Colors.transparent,
         theme: ThemeData(
           useMaterial3: true,
           colorScheme: colorScheme,

--- a/lib/ui/screens/home_dashboard.dart
+++ b/lib/ui/screens/home_dashboard.dart
@@ -112,7 +112,9 @@ class HomeDashboard extends ConsumerWidget {
                         .filter()
                         .albumEqualTo(album.name)
                         .findAll();
-                    ref.read(appNavigationProvider.notifier).showCollection(
+                    ref
+                        .read(appNavigationProvider.notifier)
+                        .showCollection(
                           title: album.name,
                           subtitle: album.artist,
                           art: album.artPath,
@@ -156,8 +158,10 @@ class HomeDashboard extends ConsumerWidget {
                           album.artist ?? 'Unknown',
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style:
-                              const TextStyle(fontSize: 11, color: Colors.grey),
+                          style: const TextStyle(
+                            fontSize: 11,
+                            color: Colors.grey,
+                          ),
                         ),
                       ],
                     ),
@@ -235,8 +239,10 @@ class HomeDashboard extends ConsumerWidget {
                           song.artist ?? 'Unknown',
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style:
-                              const TextStyle(fontSize: 11, color: Colors.grey),
+                          style: const TextStyle(
+                            fontSize: 11,
+                            color: Colors.grey,
+                          ),
                         ),
                       ],
                     ),
@@ -303,7 +309,9 @@ class HomeDashboard extends ConsumerWidget {
                     padding: const EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       color: isCurrent
-                          ? Theme.of(context).colorScheme.primary.withOpacity(0.5)
+                          ? Theme.of(
+                              context,
+                            ).colorScheme.primary.withOpacity(0.5)
                           : Colors.white.withOpacity(0.02),
                       borderRadius: BorderRadius.circular(8),
                     ),
@@ -405,10 +413,7 @@ class _FeaturedArtistCard extends ConsumerWidget {
   final Artist artist;
   final bool isNarrow;
 
-  const _FeaturedArtistCard({
-    required this.artist,
-    required this.isNarrow,
-  });
+  const _FeaturedArtistCard({required this.artist, required this.isNarrow});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -420,7 +425,9 @@ class _FeaturedArtistCard extends ConsumerWidget {
               .filter()
               .artistEqualTo(artist.name)
               .findAll();
-          ref.read(appNavigationProvider.notifier).showCollection(
+          ref
+              .read(appNavigationProvider.notifier)
+              .showCollection(
                 title: artist.name,
                 subtitle: 'Artist',
                 art: artist.artPath,

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -30,6 +30,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:looper_player/features/library/presentation/library_grids.dart';
 import 'package:looper_player/l10n/app_localizations.dart';
 import '../widgets/global_search_bar.dart';
+import 'package:looper_player/features/playback/presentation/widgets/overlay_lyrics_widget.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -83,11 +84,20 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final bool showWelcome = library.songs.isEmpty && !library.isScanning;
     final bool isNarrow = MediaQuery.of(context).size.width < 800;
 
+    final isOverlayMode = ref.watch(overlayModeProvider);
+
+    if (isOverlayMode) {
+      return const Scaffold(
+        backgroundColor: Colors.transparent,
+        body: OverlayLyricsWidget(),
+      );
+    }
+
     return Scaffold(
       backgroundColor: isDynamic
           ? (playback.currentSong != null
-              ? Theme.of(context).colorScheme.background
-              : null)
+                ? Theme.of(context).colorScheme.background
+                : null)
           : null,
       drawer: isNarrow
           ? Drawer(
@@ -169,23 +179,42 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                                       children: [
                                         if (nav.activeItem != NavItem.lyrics)
                                           Padding(
-                                            padding: const EdgeInsets.symmetric(horizontal: 24),
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 24,
+                                            ),
                                             child: Row(
                                               children: [
                                                 AnimatedContainer(
-                                                  duration: const Duration(milliseconds: 300),
+                                                  duration: const Duration(
+                                                    milliseconds: 300,
+                                                  ),
                                                   curve: Curves.easeInOutCubic,
-                                                  width: nav.history.isEmpty ? 0 : 120,
+                                                  width: nav.history.isEmpty
+                                                      ? 0
+                                                      : 120,
                                                   child: ClipRect(
                                                     child: AnimatedScale(
-                                                      scale: nav.history.isEmpty ? 0.0 : 1.0,
-                                                      duration: const Duration(milliseconds: 300),
+                                                      scale: nav.history.isEmpty
+                                                          ? 0.0
+                                                          : 1.0,
+                                                      duration: const Duration(
+                                                        milliseconds: 300,
+                                                      ),
                                                       curve: Curves.easeOutBack,
                                                       child: Padding(
-                                                        padding: const EdgeInsets.only(right: 16),
+                                                        padding:
+                                                            const EdgeInsets.only(
+                                                              right: 16,
+                                                            ),
                                                         child: _HeaderButton(
-                                                          onTap: () => ref.read(appNavigationProvider.notifier).goBack(),
-                                                          icon: LucideIcons.arrowLeft,
+                                                          onTap: () => ref
+                                                              .read(
+                                                                appNavigationProvider
+                                                                    .notifier,
+                                                              )
+                                                              .goBack(),
+                                                          icon: LucideIcons
+                                                              .arrowLeft,
                                                           label: 'Back',
                                                           isDynamic: isDynamic,
                                                         ),
@@ -193,14 +222,24 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                                                     ),
                                                   ),
                                                 ),
-                                                const Expanded(child: GlobalSearchBar()),
+                                                const Expanded(
+                                                  child: GlobalSearchBar(),
+                                                ),
                                                 // const SizedBox(width: 48),
                                                 Spacer(),
                                                 _HeaderButton(
                                                   onTap: () async {
-                                                    final String? path = await FilePicker.platform.getDirectoryPath();
+                                                    final String? path =
+                                                        await FilePicker
+                                                            .platform
+                                                            .getDirectoryPath();
                                                     if (path != null) {
-                                                      ref.read(libraryProvider.notifier).scanLibrary(path);
+                                                      ref
+                                                          .read(
+                                                            libraryProvider
+                                                                .notifier,
+                                                          )
+                                                          .scanLibrary(path);
                                                     }
                                                   },
                                                   icon: LucideIcons.plus,
@@ -236,8 +275,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ),
     );
   }
-
-
 
   Widget _buildMainContent(
     NavigationState nav,
@@ -374,7 +411,9 @@ class Sidebar extends ConsumerWidget {
                             child: SvgPicture.asset(
                               'assets/main_logo.svg',
                               fit: BoxFit.contain,
-                              colorMapper: AccentColorMapper(Theme.of(context).colorScheme.primary),
+                              colorMapper: AccentColorMapper(
+                                Theme.of(context).colorScheme.primary,
+                              ),
                             ),
                           ),
                         ],
@@ -477,11 +516,13 @@ class _HeaderButton extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 20),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(30),
-          color: const Color.fromARGB(255, 53, 53, 53).withOpacity(isDynamic ? 0.3 : 0.1),
-          border: Border.all(
-            color: Colors.white10.withOpacity(0.1),
-            width: 1,
-          ),
+          color: const Color.fromARGB(
+            255,
+            53,
+            53,
+            53,
+          ).withOpacity(isDynamic ? 0.3 : 0.1),
+          border: Border.all(color: Colors.white10.withOpacity(0.1), width: 1),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
@@ -561,5 +602,3 @@ class _SidebarItem extends StatelessWidget {
     );
   }
 }
-
-

--- a/lib/ui/screens/settings_view.dart
+++ b/lib/ui/screens/settings_view.dart
@@ -116,10 +116,7 @@ class SettingsView extends ConsumerWidget {
           title: l10n.about,
           children: [
             ListTile(
-              leading: Image.asset(
-                'assets/icon.png',
-                height: 24,
-              ),
+              leading: Image.asset('assets/icon.png', height: 24),
               title: const Text('Looper Player'),
               subtitle: const Text('Version 1.0.0'),
             ),

--- a/lib/ui/widgets/collection_detail_view.dart
+++ b/lib/ui/widgets/collection_detail_view.dart
@@ -33,7 +33,8 @@ class CollectionDetailView extends ConsumerWidget {
             children: [
               // Header
               Container(
-                padding: EdgeInsets.symmetric(horizontal:  isNarrow ? 16 : 32,
+                padding: EdgeInsets.symmetric(
+                  horizontal: isNarrow ? 16 : 32,
                   vertical: isNarrow ? 12 : 16,
                 ),
                 child: isNarrow

--- a/lib/ui/widgets/global_search_bar.dart
+++ b/lib/ui/widgets/global_search_bar.dart
@@ -49,8 +49,6 @@ class _GlobalSearchBarState extends ConsumerState<GlobalSearchBar> {
     // Remove global watch of searchQueryProvider to prevent rebuilds on every keystroke
     // final query = ref.watch(searchQueryProvider);
 
-
-
     if (nav.activeItem == NavItem.lyrics) {
       return const SizedBox.shrink();
     }
@@ -71,7 +69,10 @@ class _GlobalSearchBarState extends ConsumerState<GlobalSearchBar> {
               53,
               53,
             ).withOpacity(isDynamic ? 0.3 : 0.1),
-            border: Border.all(color: Colors.white10.withOpacity(0.1), width: 1),
+            border: Border.all(
+              color: Colors.white10.withOpacity(0.1),
+              width: 1,
+            ),
             boxShadow: [
               if (!isDynamic)
                 BoxShadow(
@@ -89,7 +90,10 @@ class _GlobalSearchBarState extends ConsumerState<GlobalSearchBar> {
                 sigmaY: isDynamic ? 5 : 0,
               ),
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 2,
+                ),
                 child: TextField(
                   focusNode: ref.watch(searchFocusNodeProvider),
                   controller: _controller,
@@ -108,7 +112,6 @@ class _GlobalSearchBarState extends ConsumerState<GlobalSearchBar> {
                       color: Colors.white.withOpacity(0.5),
                       fontSize: 14,
                       fontFamily: 'DMSans',
-                      
                     ),
                     prefixIcon: SizedBox(
                       width: 50,

--- a/lib/ui/widgets/player_bar.dart
+++ b/lib/ui/widgets/player_bar.dart
@@ -371,7 +371,9 @@ class _PremiumPlayerBar extends StatelessWidget {
               colorFilter: repeatMode == RepeatMode.one
                   ? null
                   : ColorFilter.mode(
-                      repeatMode == RepeatMode.all ? Colors.white : Colors.white38,
+                      repeatMode == RepeatMode.all
+                          ? Colors.white
+                          : Colors.white38,
                       BlendMode.srcIn,
                     ),
               colorMapper: repeatMode == RepeatMode.one
@@ -513,8 +515,9 @@ class _ExpressiveSlider extends StatelessWidget {
   Widget _buildAnimatedDuration(String duration, bool isRightAligned) {
     return Row(
       mainAxisSize: MainAxisSize.min,
-      mainAxisAlignment:
-          isRightAligned ? MainAxisAlignment.end : MainAxisAlignment.start,
+      mainAxisAlignment: isRightAligned
+          ? MainAxisAlignment.end
+          : MainAxisAlignment.start,
       children: duration.characters.map((char) {
         return SizedBox(
           width: char == ':' ? 4 : 8,
@@ -528,10 +531,7 @@ class _ExpressiveSlider extends StatelessWidget {
                     begin: Offset(0.0, isIn ? 0.5 : -0.5),
                     end: Offset.zero,
                   ).animate(animation),
-                  child: FadeTransition(
-                    opacity: animation,
-                    child: child,
-                  ),
+                  child: FadeTransition(opacity: animation, child: child),
                 ),
               );
             },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -761,10 +761,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1358,10 +1358,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
🎯 **What**
Added a "Picture-in-Picture" style overlay mode for the lyrics screen. This mode transitions the main application window into a small, borderless, always-on-top overlay that resides securely above other desktop windows.

💡 **Why**
Users wanted a way to read lyrics without keeping the full music player application window actively focused or taking up screen real estate. Furthermore, the standard `LyricsView` renderer is resource-heavy, so providing an optimized view for passive reading reduces overall CPU and RAM usage.

✅ **Verification**
- Ensured windowManager transition logic saves old bounds and restores properly.
- Ensured the `OverlayLyricsWidget` updates flawlessly as position changes but avoids heavy list-rebuilding.
- Code reviewed cleanly via `dart analyze`.

✨ **Result**
A clean, frameless, transparent UI where users can see the current and next line of a song lyrics securely, effectively working like a modern lyrics widget on the desktop.

---
*PR created automatically by Jules for task [16341643803128603899](https://jules.google.com/task/16341643803128603899) started by @SthrNilshaaa*