### PR TITLE
feat: Add lyrics overlay mode

### DIFF
--- a/lib/features/playback/presentation/lyrics_view.dart
+++ b/lib/features/playback/presentation/lyrics_view.dart
@@ -24,54 +24,69 @@ class _LyricsViewState extends ConsumerState<LyricsView> {
   @override
   Widget build(BuildContext context) {
     final lyricsState = ref.watch(lyricsProvider);
-    final currentSong = ref.watch(
-      playbackProvider.select((s) => s.currentSong),
-    );
     final primaryColor = Theme.of(context).colorScheme.primary;
 
-    return Column(
+    return Stack(
       children: [
-        _buildHeader(currentSong),
-        if (_syncMode != LyricsSyncMode.line) _buildDisclaimer(),
-        Expanded(
-          child: lyricsState.isLoading
-              ? const Center(child: CircularProgressIndicator())
-              : lyricsState.rawLrc == null
-              ? Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        Icons.music_note,
-                        size: 80,
-                        color: primaryColor.withOpacity(0.3),
+        Column(
+          children: [
+            const SizedBox(height: 48), // Space for floating button
+            if (_syncMode != LyricsSyncMode.line) _buildDisclaimer(),
+            Expanded(
+              child: lyricsState.isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : lyricsState.rawLrc == null
+                  ? Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.music_note,
+                            size: 80,
+                            color: primaryColor.withOpacity(0.3),
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            'Lyrics not available.',
+                            style: GoogleFonts.spaceGrotesk(
+                              color: Colors.white.withOpacity(0.4),
+                              fontSize: 18,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ],
                       ),
-                      const SizedBox(height: 16),
-                      Text(
-                        'Lyrics not available.',
-                        style: GoogleFonts.spaceGrotesk(
-                          color: Colors.white.withOpacity(0.4),
-                          fontSize: 18,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                    ],
-                  ),
-                )
-              : Consumer(
-                  builder: (context, ref, child) {
-                    final position = ref.watch(
-                      playbackProvider.select((s) => s.position),
-                    );
-                    return AdvancedLyricRenderer(
-                      lines: lyricsState.parsedLines,
-                      currentPosition: position,
-                      mode: _syncMode,
-                      onSeek: (pos) =>
-                          ref.read(playbackProvider.notifier).seek(pos),
-                    );
-                  },
-                ),
+                    )
+                  : Consumer(
+                      builder: (context, ref, child) {
+                        final position = ref.watch(
+                          playbackProvider.select((s) => s.position),
+                        );
+                        return AdvancedLyricRenderer(
+                          lines: lyricsState.parsedLines,
+                          currentPosition: position,
+                          mode: _syncMode,
+                          onSeek: (pos) =>
+                              ref.read(playbackProvider.notifier).seek(pos),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+        Positioned(
+          top: 16,
+          right: 16,
+          child: IconButton(
+            icon: const Icon(
+              LucideIcons.pictureInPicture2,
+              color: Colors.white70,
+            ),
+            tooltip: 'Overlay Lyrics',
+            onPressed: () {
+              ref.read(overlayServiceProvider).toggleOverlay();
+            },
+          ),
         ),
       ],
     );
@@ -100,169 +115,6 @@ class _LyricsViewState extends ConsumerState<LyricsView> {
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildHeader(Song? currentSong) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final bool isNarrow = constraints.maxWidth < 600;
-        final bool isShort = MediaQuery.of(context).size.height < 500;
-
-        return Padding(
-          padding: EdgeInsets.symmetric(
-            vertical: isNarrow || isShort ? 8 : 24,
-            horizontal: isNarrow ? 16 : 32,
-          ),
-          child: isNarrow
-              ? Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (currentSong != null) ...[
-                      _buildSongInfoCompact(currentSong, isShort),
-                      SizedBox(height: isShort ? 8 : 16),
-                    ],
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        _buildModeSelector(isShort),
-                        const SizedBox(width: 16),
-                        IconButton(
-                          icon: const Icon(
-                            LucideIcons.pictureInPicture2,
-                            color: Colors.white70,
-                          ),
-                          tooltip: 'Overlay Lyrics',
-                          onPressed: () {
-                            ref.read(overlayServiceProvider).toggleOverlay();
-                          },
-                        ),
-                      ],
-                    ),
-                  ],
-                )
-              : Row(
-                  children: [
-                    if (currentSong != null) ...[
-                      _buildArt(currentSong, isShort ? 60 : 80),
-                      const SizedBox(width: 24),
-                      Expanded(child: _buildSongText(currentSong, isShort)),
-                    ],
-                    _buildModeSelector(isShort),
-                    const SizedBox(width: 16),
-                    IconButton(
-                      icon: const Icon(
-                        LucideIcons.pictureInPicture2,
-                        color: Colors.white70,
-                      ),
-                      tooltip: 'Overlay Lyrics',
-                      onPressed: () {
-                        ref.read(overlayServiceProvider).toggleOverlay();
-                      },
-                    ),
-                  ],
-                ),
-        );
-      },
-    );
-  }
-
-  Widget _buildArt(Song currentSong, double size) {
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
-        color: Colors.white.withOpacity(0.05),
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: currentSong.artPath == null
-          ? Icon(Icons.music_note, color: Colors.grey[600], size: size / 2)
-          : Image.file(
-              File(currentSong.artPath!),
-              fit: BoxFit.cover,
-              cacheWidth: size.toInt() * 2,
-            ),
-    );
-  }
-
-  Widget _buildSongText(Song currentSong, bool isShort) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(
-          currentSong.title,
-          style: GoogleFonts.spaceGrotesk(
-            fontSize: isShort ? 20 : 28,
-            fontWeight: FontWeight.normal,
-          ),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-        Text(
-          currentSong.artist ?? 'Unknown Artist',
-          style: GoogleFonts.spaceGrotesk(
-            fontSize: isShort ? 14 : 18,
-            color: Colors.grey[400],
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildSongInfoCompact(Song currentSong, bool isShort) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Container(
-          width: isShort ? 40 : 50,
-          height: isShort ? 40 : 50,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(8),
-            color: Colors.white.withOpacity(0.05),
-          ),
-          clipBehavior: Clip.antiAlias,
-          child: currentSong.artPath == null
-              ? Icon(
-                  Icons.music_note,
-                  color: Colors.grey[600],
-                  size: isShort ? 20 : 24,
-                )
-              : Image.file(
-                  File(currentSong.artPath!),
-                  fit: BoxFit.cover,
-                  cacheWidth: (isShort ? 40 : 50) * 2,
-                ),
-        ),
-        const SizedBox(width: 12),
-        Flexible(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                currentSong.title,
-                style: GoogleFonts.spaceGrotesk(
-                  fontSize: isShort ? 14 : 18,
-                  fontWeight: FontWeight.normal,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              Text(
-                currentSong.artist ?? 'Unknown Artist',
-                style: GoogleFonts.spaceGrotesk(
-                  fontSize: isShort ? 12 : 14,
-                  color: Colors.grey[400],
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ],
-          ),
-        ),
-      ],
     );
   }
 

--- a/lib/features/playback/presentation/overlay_service.dart
+++ b/lib/features/playback/presentation/overlay_service.dart
@@ -35,10 +35,11 @@ class OverlayService {
     await windowManager.setBackgroundColor(Colors.transparent);
 
     // Set to a smaller size suitable for lyrics
-    await windowManager.setSize(const Size(500, 150));
-    await windowManager.setOpacity(
-      1.0,
-    ); // Make sure the window isn't entirely invisible
+    await windowManager.setSize(const Size(400, 150));
+    // Provide a small delay to ensure the OS has applied the borderless state
+    // before the window is resized.
+    await Future.delayed(const Duration(milliseconds: 50));
+    await windowManager.setBackgroundColor(Colors.transparent);
   }
 
   Future<void> exitOverlay() async {

--- a/lib/features/playback/presentation/widgets/overlay_lyrics_widget.dart
+++ b/lib/features/playback/presentation/widgets/overlay_lyrics_widget.dart
@@ -17,6 +17,8 @@ class OverlayLyricsWidget extends ConsumerStatefulWidget {
 }
 
 class _OverlayLyricsWidgetState extends ConsumerState<OverlayLyricsWidget> {
+  Size? _initialSize;
+
   @override
   Widget build(BuildContext context) {
     // Only rebuild when the parsed lines change
@@ -33,7 +35,7 @@ class _OverlayLyricsWidgetState extends ConsumerState<OverlayLyricsWidget> {
       },
       child: Container(
         color: Colors.black.withOpacity(0.5),
-        padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0),
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
         child: Stack(
           children: [
             Center(
@@ -68,7 +70,7 @@ class _OverlayLyricsWidgetState extends ConsumerState<OverlayLyricsWidget> {
                         currentLine,
                         textAlign: TextAlign.center,
                         style: GoogleFonts.spaceGrotesk(
-                          fontSize: 26,
+                          fontSize: 20,
                           fontWeight: FontWeight.bold,
                           color: Theme.of(context).colorScheme.primary,
                         ),
@@ -76,12 +78,12 @@ class _OverlayLyricsWidgetState extends ConsumerState<OverlayLyricsWidget> {
                         overflow: TextOverflow.ellipsis,
                       ),
                       if (nextLine.isNotEmpty) ...[
-                        const SizedBox(height: 8),
+                        const SizedBox(height: 4),
                         Text(
                           nextLine,
                           textAlign: TextAlign.center,
                           style: GoogleFonts.spaceGrotesk(
-                            fontSize: 16,
+                            fontSize: 14,
                             color: Colors.white70,
                           ),
                           maxLines: 1,
@@ -115,11 +117,28 @@ class _OverlayLyricsWidgetState extends ConsumerState<OverlayLyricsWidget> {
             ),
             // Resize handle on the bottom right
             Positioned(
-              bottom: -5,
-              right: -5,
+              bottom: 0,
+              right: 0,
               child: GestureDetector(
-                onPanStart: (details) {
-                  windowManager.startResizing(ResizeEdge.bottomRight);
+                onPanStart: (details) async {
+                  _initialSize = await windowManager.getSize();
+                },
+                onPanUpdate: (details) async {
+                  if (_initialSize != null) {
+                    final newWidth =
+                        _initialSize!.width + details.localPosition.dx;
+                    final newHeight =
+                        _initialSize!.height + details.localPosition.dy;
+
+                    // Enforce a minimum size
+                    final width = newWidth < 100 ? 100.0 : newWidth;
+                    final height = newHeight < 50 ? 50.0 : newHeight;
+
+                    await windowManager.setSize(Size(width, height));
+                  }
+                },
+                onPanEnd: (details) {
+                  _initialSize = null;
                 },
                 child: MouseRegion(
                   cursor: SystemMouseCursors.resizeDownRight,

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -96,9 +96,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return Scaffold(
       backgroundColor: isDynamic
           ? (playback.currentSong != null
-                ? Theme.of(context).colorScheme.background
-                : null)
-          : null,
+                ? Theme.of(context).colorScheme.surface
+                : Theme.of(context).scaffoldBackgroundColor)
+          : Theme.of(context).scaffoldBackgroundColor,
       drawer: isNarrow
           ? Drawer(
               child: Container(


### PR DESCRIPTION
Adds a transparent, always-on-top, borderless overlay window specifically for displaying lyrics.

- Introduce `overlayModeProvider` and `OverlayService` to handle windowManager transition logic.
- Replace main UI with `OverlayLyricsWidget` which renders the active and upcoming lyrics utilizing the pre-existing `AdvancedLyricRenderer` to maintain the user's preferred animations.
- Introduce a custom drag-to-resize handle at the bottom right that accurately tracks mouse delta, as native Linux resize handles are notoriously broken for frameless windows.
- Update global backgrounds to safely fall back to transparent when the overlay is active, while preserving the main app's dark gray surface color when in standard mode.
- Remove redundant headers from the standard LyricsView and replace them with a floating Picture-in-Picture action button.