### PR TITLE
🧹 [Fix] Equalizer functionality and toggle resets

### DIFF
--- a/lib/core/audio_service.dart
+++ b/lib/core/audio_service.dart
@@ -678,12 +678,6 @@ class AudioService {
       }
     }
 
-    // ── SoX resampler (last in chain, always active) ─────────────────────────
-    // Must be the final filter so it converts the processed float32 signal to
-    // the device's native sample rate using the highest-quality algorithm.
-    // Pass-through when input rate == output device rate (zero overhead).
-    customFilters.add(_soxrFilter);
-
     // 2. Dynamic Range Compressor
     final bool compEnabled =
         enabled && (gains.length > 23 ? gains[23] == 1.0 : false);

--- a/lib/features/playback/presentation/equalizer_notifier.dart
+++ b/lib/features/playback/presentation/equalizer_notifier.dart
@@ -198,6 +198,42 @@ class EqualizerNotifier extends StateNotifier<EqualizerState> {
 
   Future<void> toggleEqualizer(bool enabled) async {
     state = state.copyWith(enabled: enabled);
+
+    // When toggling on, reset sub-toggles to false in current/global state
+    if (enabled) {
+      final newSongGains = List<double>.from(state.currentSongGains);
+      final newGlobalGains = List<double>.from(state.globalGains);
+
+      // Disable toggles
+      if (newSongGains.length > 19) newSongGains[19] = 0.0; // silence trim
+      if (newSongGains.length > 21) newSongGains[21] = 0.0; // crossfeed
+      if (newSongGains.length > 23) newSongGains[23] = 0.0; // compressor
+      if (newSongGains.length > 28) newSongGains[28] = 0.0; // loudnorm
+      if (newSongGains.length > 30) newSongGains[30] = 0.0; // stereo width
+      if (newSongGains.length > 38) newSongGains[38] = 0.0; // speech filter
+      if (newSongGains.length > 41) newSongGains[41] = 0.0; // lofi
+      if (newSongGains.length > 42) newSongGains[42] = 0.0; // reverb
+      if (newSongGains.length > 43) newSongGains[43] = 0.0; // surround
+      if (newSongGains.length > 44) newSongGains[44] = 0.0; // shelving
+      // Don't disable pitchTempo (45) by default as it controls normal playback speed
+
+      if (newGlobalGains.length > 19) newGlobalGains[19] = 0.0;
+      if (newGlobalGains.length > 21) newGlobalGains[21] = 0.0;
+      if (newGlobalGains.length > 23) newGlobalGains[23] = 0.0;
+      if (newGlobalGains.length > 28) newGlobalGains[28] = 0.0;
+      if (newGlobalGains.length > 30) newGlobalGains[30] = 0.0;
+      if (newGlobalGains.length > 38) newGlobalGains[38] = 0.0;
+      if (newGlobalGains.length > 41) newGlobalGains[41] = 0.0;
+      if (newGlobalGains.length > 42) newGlobalGains[42] = 0.0;
+      if (newGlobalGains.length > 43) newGlobalGains[43] = 0.0;
+      if (newGlobalGains.length > 44) newGlobalGains[44] = 0.0;
+
+      state = state.copyWith(
+        currentSongGains: newSongGains,
+        globalGains: newGlobalGains,
+      );
+    }
+
     await ref.read(settingsProvider.notifier).updateEqualizerEnabled(enabled);
     applyEqualizerInstant();
   }
@@ -278,7 +314,7 @@ class EqualizerNotifier extends StateNotifier<EqualizerState> {
       } else {
         final audioSvc = ref.read(audioServiceProvider);
         audioSvc.setEqualizerGains(
-          newGlobalGains,
+          newSongGains,
           state.enabled,
           customFilter: state.customFilterString,
         );
@@ -292,7 +328,7 @@ class EqualizerNotifier extends StateNotifier<EqualizerState> {
       });
 
       state = state.copyWith(
-        currentSongGains: newGlobalGains,
+        currentSongGains: newSongGains,
         globalGains: newGlobalGains,
         currentSongHasCustom: false,
       );
@@ -644,8 +680,8 @@ class EqualizerNotifier extends StateNotifier<EqualizerState> {
 
       _persistGainsDebounced(songGains: newSongGains, globalGains: null);
     } else {
-      final newSongGains = List<double>.from(state.globalGains);
-      newSongGains[bandIndex] = clampedGain;
+      final newGlobalGains = List<double>.from(state.globalGains);
+      newGlobalGains[bandIndex] = clampedGain;
 
       state = state.copyWith(
         currentSongGains: newGlobalGains,


### PR DESCRIPTION
🎯 **What**
Fixed a critical bug where equalizer filters (excluding pitch/tempo) were ignored by the audio engine, and ensured all EQ sub-toggles correctly reset when the master toggle is enabled.

💡 **Why**
- **Equalizer Engine Failure:** In `AudioService.setEqualizerGains()`, the `_soxrFilter` (which defines the resampling filter with ID `@aek_soxr`) was erroneously being added to the `customFilters` list *twice*. `mpv_audio_kit` treats the `custom` list as an audio filter string (`af`). Duplicate filter labels invalidate the entire chain, causing mpv to silently drop all equalizer effects. (Pitch and Tempo continued working because they bypass the `af` chain and call `setPitch()` / `setRate()` directly).
- **Sub-Toggle Resetting:** The user requested that enabling the global equalizer automatically zeros out the sub-effects (like compressor, lofi, reverb, silence trim, etc.).

✅ **Verification**
- Removed the duplicate insertion of `_soxrFilter` in `audio_service.dart`.
- Added reset logic in `EqualizerNotifier.toggleEqualizer()` to zero out specific indexes mapped to sub-toggles (indexes 19 through 44, skipping 45 for `pitchTempoEnabled`).
- Formatted and analyzed changes.

✨ **Result**
The equalizer effects now route through the audio player correctly, and toggling the global equalizer ensures a clean baseline state for the sub-features.

---
*PR created automatically by Jules for task [5194044560352791828](https://jules.google.com/task/5194044560352791828) started by @SthrNilshaaa*